### PR TITLE
Feat : Connect BackEnd API Authorize,  Add TokenManger(object), Save the access token & refresh token in DataStore, add HistoryRetrofit

### DIFF
--- a/fatman/app/src/main/java/com/project/fat/MapsActivity.kt
+++ b/fatman/app/src/main/java/com/project/fat/MapsActivity.kt
@@ -182,9 +182,10 @@ class MapsActivity : AppCompatActivity(), OnMapReadyCallback {
         mMap.moveCamera(camera)
 
         for(i in markerCnt..Marker.MAXNUM_MARKER) {
-            Handler(Looper.getMainLooper()).postDelayed({
-                setMonsterMarker(icon, location)
-            }, Random.nextLong(Marker.MIN_TIME, Marker.MAX_TIME))
+            setMonsterMarker(icon, location)
+//            Handler(Looper.getMainLooper()).postDelayed({
+//                setMonsterMarker(icon, location)
+//            }, Random.nextLong(Marker.MIN_TIME, Marker.MAX_TIME))
         }
     }
 

--- a/fatman/app/src/main/java/com/project/fat/ResultActivity.kt
+++ b/fatman/app/src/main/java/com/project/fat/ResultActivity.kt
@@ -6,16 +6,20 @@ import android.os.Bundle
 import androidx.lifecycle.lifecycleScope
 import com.google.android.filament.IndirectLight
 import com.project.fat.RunningTimeActivity.Companion.runningFinalData
+import com.project.fat.data.dto.CreateHistoryResponse
 import com.project.fat.databinding.ActivityResultBinding
+import com.project.fat.retrofit.client.HistoryRetrofit
 import io.github.sceneview.math.Position
 import io.github.sceneview.math.Rotation
 import io.github.sceneview.node.ModelNode
 import io.github.sceneview.utils.colorOf
+import retrofit2.Call
 
 class ResultActivity : AppCompatActivity() {
     private lateinit var binding: ActivityResultBinding
     private var modelUrl : String? = null
 
+    private lateinit var callCreateFillEventHistory: Call<CreateHistoryResponse>
     private lateinit var modelNode: ModelNode
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -24,6 +28,7 @@ class ResultActivity : AppCompatActivity() {
         setContentView(binding.root)
 
         modelUrl = intent.getStringExtra("glbFileLocation")
+
 
         modelNode = ModelNode(binding.monster3d.engine).apply {
             position = Position(x = 0.0f, y = 0.0f, z = -4.0f)

--- a/fatman/app/src/main/java/com/project/fat/ResultActivity.kt
+++ b/fatman/app/src/main/java/com/project/fat/ResultActivity.kt
@@ -3,23 +3,36 @@ package com.project.fat
 import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.util.Log
+import android.widget.Toast
+import androidx.datastore.preferences.core.edit
 import androidx.lifecycle.lifecycleScope
 import com.google.android.filament.IndirectLight
 import com.project.fat.RunningTimeActivity.Companion.runningFinalData
 import com.project.fat.data.dto.CreateHistoryResponse
+import com.project.fat.dataStore.UserDataStoreKey
+import com.project.fat.dataStore.UserDataStoreKey.USER_ID
+import com.project.fat.dataStore.UserDataStoreKey.dataStore
 import com.project.fat.databinding.ActivityResultBinding
 import com.project.fat.retrofit.client.HistoryRetrofit
+import com.project.fat.tokenManager.TokenManager
 import io.github.sceneview.math.Position
 import io.github.sceneview.math.Rotation
 import io.github.sceneview.node.ModelNode
 import io.github.sceneview.utils.colorOf
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+import java.lang.Exception
 
 class ResultActivity : AppCompatActivity() {
     private lateinit var binding: ActivityResultBinding
     private var modelUrl : String? = null
 
-    private lateinit var callCreateFillEventHistory: Call<CreateHistoryResponse>
+    private lateinit var callCreateHistory: Call<CreateHistoryResponse>
     private lateinit var modelNode: ModelNode
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -46,8 +59,6 @@ class ResultActivity : AppCompatActivity() {
 
         binding.goHome.setOnClickListener{
             sendNewHistory()
-            startActivity(Intent(this, BottomNavigationActivity::class.java))
-            finish()
         }
 
         val background = colorOf(resources.getColor(R.color.translucent_white))
@@ -62,5 +73,55 @@ class ResultActivity : AppCompatActivity() {
 
     private fun sendNewHistory(){
         //REST API createHistory
+        lifecycleScope.launch {
+            this@ResultActivity.dataStore.data.map {
+                val todayMonsterNum = (it[UserDataStoreKey.TODAY_MONSTER_NUM] ?: 0) + 1
+                val accessToken = TokenManager.getAccessToken()
+
+                callCreateHistory = HistoryRetrofit.getApiService()!!.createHistory(accessToken.toString(), todayMonsterNum, runningFinalData!!.distance.toDouble(), runningFinalData!!.time)
+                callCreateHistory.enqueue(object : Callback<CreateHistoryResponse>{
+                    override fun onResponse(
+                        call: Call<CreateHistoryResponse>,
+                        response: Response<CreateHistoryResponse>
+                    ) {
+                        if(response.isSuccessful){
+                            val result = response.body()
+                            if(result != null){
+                                saveTodayMonsterNum(todayMonsterNum)
+                            }else{
+                                Log.d("BackEnd API createHistory result is null", "val result : SocialLoginResponse? = response.body()")
+                            }
+                        }else{
+                            Log.d("BackEnd API SocialLogin response not successful", "Error : ${response.code()}")
+                        }
+                    }
+
+                    override fun onFailure(
+                        call: Call<CreateHistoryResponse>,
+                        t: Throwable
+                    ) {
+                        Log.d("BackEnd API SocialLogin Failure", "Fail : ${t.printStackTrace()}\n Error message : ${t.message}")
+                        Toast.makeText(this@ResultActivity, "전송 오류 : 다시 시도해주세요.", Toast.LENGTH_SHORT).show()
+                    }
+
+                })
+            }
+        }
+    }
+
+    private fun saveTodayMonsterNum(todayMonsterNum : Int){
+        lifecycleScope.launch {
+            applicationContext.dataStore.edit {
+                Log.d("saveTodayMonsterNum", "start")
+                it[UserDataStoreKey.TODAY_MONSTER_NUM] = todayMonsterNum
+                Log.d("saveTodayMonsterNum", "end")
+            }
+            goHome()
+        }
+    }
+
+    private fun goHome(){
+        startActivity(Intent(this@ResultActivity, BottomNavigationActivity::class.java))
+        finish()
     }
 }

--- a/fatman/app/src/main/java/com/project/fat/RunningTimeActivity.kt
+++ b/fatman/app/src/main/java/com/project/fat/RunningTimeActivity.kt
@@ -52,6 +52,7 @@ class RunningTimeActivity : AppCompatActivity() {
         binding.imageView.setOnClickListener {
             saveRunningFinalData()
             //임시
+            LocationProvider.stopLocationUpdates()
             startActivity(Intent(this, ArActivity::class.java))
         }
 

--- a/fatman/app/src/main/java/com/project/fat/data/dto/AuthorizeResponse.kt
+++ b/fatman/app/src/main/java/com/project/fat/data/dto/AuthorizeResponse.kt
@@ -1,0 +1,8 @@
+package com.project.fat.data.dto
+
+import retrofit2.http.Header
+
+data class AuthorizeResponse(
+    @Header("Refresh-Token") val refreshToken : String,
+    @Header("Access-Token") val accessToken : String
+)

--- a/fatman/app/src/main/java/com/project/fat/data/dto/CreateHistoryResponse.kt
+++ b/fatman/app/src/main/java/com/project/fat/data/dto/CreateHistoryResponse.kt
@@ -1,0 +1,22 @@
+package com.project.fat.data.dto
+
+data class CreateHistoryResponse (
+    val monsterNum: Long,
+    val distance: Long,
+    val id: Long,
+    val user: CreateHistoryUser,
+    val date: String
+)
+
+data class CreateHistoryUser (
+    val createdAt: String,
+    val updatedAt: String,
+    val id: Long,
+    val email: String,
+    val name: String,
+    val nickname: String,
+    val birth: String,
+    val social: Any? = null,
+    val address: String,
+    val activated: Boolean
+)

--- a/fatman/app/src/main/java/com/project/fat/data/dto/EmptyResponse.kt
+++ b/fatman/app/src/main/java/com/project/fat/data/dto/EmptyResponse.kt
@@ -1,0 +1,3 @@
+package com.project.fat.data.dto
+
+class EmptyResponse()

--- a/fatman/app/src/main/java/com/project/fat/data/dto/GetHistoryResponse.kt
+++ b/fatman/app/src/main/java/com/project/fat/data/dto/GetHistoryResponse.kt
@@ -1,0 +1,23 @@
+package com.project.fat.data.dto
+
+data class GetHistoryResponse (
+    val id: Long,
+    val user: GetHistoryUser,
+    val date: String,
+    val monsterNum: Long,
+    val distance: Long
+)
+
+data class GetHistoryUser (
+    val createdAt: String,
+    val updatedAt: String,
+    val id: Long,
+    val email: String,
+    val name: String,
+    val role: String? = null,
+    val nickname: String,
+    val birth: String,
+    val authProvider: String? = null,
+    val address: String,
+    val activated: Boolean
+)

--- a/fatman/app/src/main/java/com/project/fat/data/dto/GetHistoryResponse.kt
+++ b/fatman/app/src/main/java/com/project/fat/data/dto/GetHistoryResponse.kt
@@ -1,23 +1,24 @@
 package com.project.fat.data.dto
 
-data class GetHistoryResponse (
+typealias GetHistoryResponse = ArrayList<GetHistoryResponseElement>
+
+data class GetHistoryResponseElement (
     val id: Long,
-    val user: GetHistoryUser,
+    val user: User,
     val date: String,
     val monsterNum: Long,
     val distance: Long
 )
 
-data class GetHistoryUser (
+data class User (
     val createdAt: String,
     val updatedAt: String,
     val id: Long,
     val email: String,
     val name: String,
-    val role: String? = null,
     val nickname: String,
     val birth: String,
-    val authProvider: String? = null,
+    val social: Any? = null,
     val address: String,
     val activated: Boolean
 )

--- a/fatman/app/src/main/java/com/project/fat/data/dto/UserFatman.kt
+++ b/fatman/app/src/main/java/com/project/fat/data/dto/UserFatman.kt
@@ -1,5 +1,7 @@
 package com.project.fat.data.dto
 
-data class UserFatman(
+typealias UserFatman = ArrayList<UserFatmanElement>
+
+data class UserFatmanElement(
     val id : Long
 )

--- a/fatman/app/src/main/java/com/project/fat/dataStore/userDataStore.kt
+++ b/fatman/app/src/main/java/com/project/fat/dataStore/userDataStore.kt
@@ -5,6 +5,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.dataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
@@ -20,5 +21,6 @@ object UserDataStoreKey{
     val SELECTED_FATMAN_IMAGE = stringPreferencesKey("selected_fatman_image")
     val ACCESS_TOKEN = stringPreferencesKey("access_token")
     val REFRESH_TOKEN = stringPreferencesKey("refresh_token")
+    val TODAY_MONSTER_NUM = intPreferencesKey("today_monster_num")
 }
 

--- a/fatman/app/src/main/java/com/project/fat/dataStore/userDataStore.kt
+++ b/fatman/app/src/main/java/com/project/fat/dataStore/userDataStore.kt
@@ -18,5 +18,7 @@ object UserDataStoreKey{
     val NAME = stringPreferencesKey("name")
     val SELECTED_FATMAN_ID = longPreferencesKey("selected_fatman_id")
     val SELECTED_FATMAN_IMAGE = stringPreferencesKey("selected_fatman_image")
+    val ACCESS_TOKEN = stringPreferencesKey("access_token")
+    val REFRESH_TOKEN = stringPreferencesKey("refresh_token")
 }
 

--- a/fatman/app/src/main/java/com/project/fat/retrofit/api_interface/FatmanService.kt
+++ b/fatman/app/src/main/java/com/project/fat/retrofit/api_interface/FatmanService.kt
@@ -1,6 +1,5 @@
 package com.project.fat.retrofit.api_interface
 
-import com.project.fat.data.dto.Fatman
 import com.project.fat.data.dto.UserFatman
 import retrofit2.Call
 import retrofit2.http.GET
@@ -16,5 +15,5 @@ interface FatmanService {
 
     @GET("userfatman")
     fun getUserFatman(
-        @Header("Access-Token") accessToken : String) : List<Call<UserFatman>>
+        @Header("Access-Token") accessToken : String) : Call<UserFatman>
 }

--- a/fatman/app/src/main/java/com/project/fat/retrofit/api_interface/HistoryService.kt
+++ b/fatman/app/src/main/java/com/project/fat/retrofit/api_interface/HistoryService.kt
@@ -1,0 +1,31 @@
+package com.project.fat.retrofit.api_interface
+
+import com.project.fat.data.dto.CreateHistoryResponse
+import com.project.fat.data.dto.GetHistoryResponse
+import retrofit2.Call
+import retrofit2.http.Body
+import retrofit2.http.DELETE
+import retrofit2.http.GET
+import retrofit2.http.Header
+import retrofit2.http.POST
+import retrofit2.http.Path
+
+interface HistoryService {
+    @GET("history")
+    fun getHistory(
+        @Header("access_token") accessToken : String
+    ) : List<Call<GetHistoryResponse>>
+
+    @POST("history")
+    fun createHistory(
+        @Header("Access-Token") accessToken : String,
+        @Body monsterNum : Int,
+        @Body distance : Double,
+        @Body date : String
+    ) :Call<CreateHistoryResponse>
+
+    @DELETE("history")
+    fun deleteHistory(
+        @Path("id") id : Long
+    )
+}

--- a/fatman/app/src/main/java/com/project/fat/retrofit/api_interface/HistoryService.kt
+++ b/fatman/app/src/main/java/com/project/fat/retrofit/api_interface/HistoryService.kt
@@ -14,7 +14,7 @@ interface HistoryService {
     @GET("history")
     fun getHistory(
         @Header("access_token") accessToken : String
-    ) : List<Call<GetHistoryResponse>>
+    ) : Call<GetHistoryResponse>
 
     @POST("history")
     fun createHistory(

--- a/fatman/app/src/main/java/com/project/fat/retrofit/api_interface/UserService.kt
+++ b/fatman/app/src/main/java/com/project/fat/retrofit/api_interface/UserService.kt
@@ -1,9 +1,12 @@
 package com.project.fat.retrofit.api_interface
 
+import com.project.fat.data.dto.AuthorizeResponse
 import com.project.fat.data.dto.SocialLoginRequest
 import com.project.fat.data.dto.SocialLoginResponse
 import retrofit2.Call
 import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.Header
 import retrofit2.http.POST
 
 interface UserService {
@@ -11,4 +14,10 @@ interface UserService {
     fun socialLogin(
         @Body token : SocialLoginRequest
     ) : Call<SocialLoginResponse>
+
+    @GET("users/refresh")
+    fun authorize(
+        @Header("Refresh-Token") refreshToken : String,
+        @Header("Access-Token") accessToken : String
+    ) : Call<AuthorizeResponse>
 }

--- a/fatman/app/src/main/java/com/project/fat/retrofit/client/HistoryRetrofit.kt
+++ b/fatman/app/src/main/java/com/project/fat/retrofit/client/HistoryRetrofit.kt
@@ -1,0 +1,38 @@
+package com.project.fat.retrofit.client
+
+import com.google.gson.GsonBuilder
+import com.project.fat.BuildConfig
+import com.project.fat.retrofit.api_interface.HistoryService
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.create
+import java.util.concurrent.TimeUnit
+
+object HistoryRetrofit {
+    private const val BASE_URL = BuildConfig.backend_api_end_point
+
+    fun getApiService() : HistoryService?{
+        return getInstance()?.create(HistoryService::class.java)
+    }
+
+    private fun getInstance(): Retrofit? {
+        val gson = GsonBuilder().setLenient().create()
+
+        val httpClient = OkHttpClient.Builder()
+            .connectTimeout(3, TimeUnit.MINUTES)
+            .readTimeout(50, TimeUnit.SECONDS)
+            .writeTimeout(30, TimeUnit.SECONDS)
+
+        val loggingInterceptor = HttpLoggingInterceptor()
+        loggingInterceptor.level = HttpLoggingInterceptor.Level.BODY
+        httpClient.addInterceptor(loggingInterceptor)
+
+        return Retrofit.Builder()
+            .baseUrl(BASE_URL)
+            .addConverterFactory(GsonConverterFactory.create(gson))
+            .client(httpClient.build())
+            .build()
+    }
+}

--- a/fatman/app/src/main/java/com/project/fat/retrofit/client/UserRetrofit.kt
+++ b/fatman/app/src/main/java/com/project/fat/retrofit/client/UserRetrofit.kt
@@ -3,10 +3,12 @@ package com.project.fat.retrofit.client
 import com.google.gson.GsonBuilder
 import com.project.fat.BuildConfig
 import com.project.fat.retrofit.api_interface.UserService
+import com.project.fat.retrofit.converterFactory.NullOnEmptyConverterFactory
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.create
 import java.util.concurrent.TimeUnit
 
 object UserRetrofit {
@@ -30,6 +32,7 @@ object UserRetrofit {
 
         return Retrofit.Builder()
             .baseUrl(BASE_URL)
+            .addConverterFactory(NullOnEmptyConverterFactory())
             .addConverterFactory(GsonConverterFactory.create(gson))
             .client(httpClient.build())
             .build()

--- a/fatman/app/src/main/java/com/project/fat/retrofit/converterFactory/NullOnEmptyConverterFactory.kt
+++ b/fatman/app/src/main/java/com/project/fat/retrofit/converterFactory/NullOnEmptyConverterFactory.kt
@@ -1,0 +1,18 @@
+package com.project.fat.retrofit.converterFactory
+
+import com.project.fat.data.dto.EmptyResponse
+import okhttp3.ResponseBody
+import retrofit2.Converter
+import retrofit2.Retrofit
+import java.lang.reflect.Type
+
+class NullOnEmptyConverterFactory : Converter.Factory() {
+    override fun responseBodyConverter(type: Type?, annotations: Array<Annotation>?, retrofit: Retrofit?): Converter<ResponseBody, *>? {
+        val delegate = retrofit!!.nextResponseBodyConverter<Any>(this, type!!, annotations!!)
+        return Converter<ResponseBody, Any> {
+            if (it.contentLength() == 0L) return@Converter EmptyResponse()
+            delegate.convert(it)
+        }
+    }
+
+}

--- a/fatman/app/src/main/java/com/project/fat/tokenManager/TokenManager.kt
+++ b/fatman/app/src/main/java/com/project/fat/tokenManager/TokenManager.kt
@@ -1,0 +1,69 @@
+package com.project.fat.tokenManager
+
+import android.util.Log
+import com.project.fat.R
+import com.project.fat.data.dto.AuthorizeResponse
+import com.project.fat.retrofit.client.UserRetrofit
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+
+object TokenManager {
+    private var accessToken : String? = null
+    private var refreshToken : String? = null
+
+    fun setToken(accessToken : String, refreshToken : String){
+        this.accessToken = accessToken
+        this.refreshToken = refreshToken
+    }
+
+    fun getAccessToken() = accessToken
+
+    fun getRefreshToken() = refreshToken
+
+    fun authorize(
+        accessToken: String,
+        refreshToken: String,
+        prefixOfAccessToken : String,
+        prefixOfRefreshToken : String,
+        callback: (Boolean) -> Unit) {
+
+        if(this.accessToken == null || this.refreshToken == null) {
+            this.accessToken = accessToken
+            this.refreshToken = refreshToken
+        }
+
+        UserRetrofit.getApiService()!!.authorize(prefixOfRefreshToken+refreshToken, prefixOfAccessToken+accessToken)
+            .enqueue(object : Callback<AuthorizeResponse>{
+                override fun onResponse(
+                    call: Call<AuthorizeResponse>,
+                    response: Response<AuthorizeResponse>
+                ) {
+                    if (response.isSuccessful) {
+                        val result = response.headers()
+                        val backendApiAccessToken = result["Access-Token"]
+                        val backendApiRefreshToken = result["Refresh-Token"]
+                        Log.d(
+                            "BackEnd API Authorize Success",
+                            "accessToken : $backendApiAccessToken\nrefreshToken : $backendApiRefreshToken"
+                        )
+                        this@TokenManager.accessToken = backendApiAccessToken!!.replace(prefixOfAccessToken, "")
+                        this@TokenManager.refreshToken = backendApiRefreshToken!!.replace(prefixOfRefreshToken, "")
+
+                        Log.d("TokenManger", "TokenManger.accessToken : ${this@TokenManager.accessToken}\nTokenManager.refreshToken : ${this@TokenManager.refreshToken}")
+                        callback(true)
+                    }
+                    else{
+                        Log.d("BackEnd API Authorize response not successful", "Error : ${response.code()}")
+                        callback(false)
+                    }
+                }
+
+                override fun onFailure(call: Call<AuthorizeResponse>, t: Throwable) {
+                    Log.d("BackEnd API Authorize Failure", "Fail : ${t.printStackTrace()}\n Error message : ${t.message}")
+                    callback(false)
+                }
+
+            })
+    }
+}

--- a/fatman/app/src/main/res/values/strings.xml
+++ b/fatman/app/src/main/res/values/strings.xml
@@ -50,4 +50,6 @@
     <string name="store_dialog_no">아뇨, 다시 고를래요.</string>
     <string name="yes">네.</string>
     <string name="no_selected_avata_title">선택된 아바타가 없습니다.</string>
+    <string name="prefix_of_access_token">auth_token:</string>
+    <string name="prefix_of_refresh_token">refresh_token:</string>
 </resources>


### PR DESCRIPTION
1. 백엔드로부터 받은 access token과 refresh token을 DataStore에 저장하는 기능을 추가하였습니다.
2. 백엔드 API의 History부분의 DTO, interface, client를 추가했습니다.
가하여 재로그인 시 AccessToken과 RefreshToken을 재발급 받도록 했습니다.
3. I/O 작업을 최소화하기 위해 앱 실행 도중에 토큰을 관리하는 TokenManager를 추가하였습니다.
4. 빈 Body가 전달되었을 때 UserRetrofit이 처리할 수 있게 EmptyResponse 클래스와 NullOnEmptyconverterFactory 클래스를 추가하였습니다.
5. RunningTimeActivity에서 ArActivity로 넘어갈 때 위치 업데이트가 제대로 종료되지 않던 문제를 해결했습니다.
6. prefix가 존재하는 데이터 양식을 위해 string.xml 파일에 prefix를 추가해두었습니다.