### PR TITLE
Fix Relogin Using AccessToken

### DIFF
--- a/fatman/app/src/main/java/com/project/fat/AdditionalInfoActivity.kt
+++ b/fatman/app/src/main/java/com/project/fat/AdditionalInfoActivity.kt
@@ -6,10 +6,12 @@ import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.util.Log
 import android.widget.Toast
+import com.project.fat.data.dto.getUserResponse
 import com.project.fat.data.dto.updateUserDetailRequest
 import com.project.fat.data.dto.updateUserDetailResponse
 import com.project.fat.dataStore.UserDataStore
 import com.project.fat.databinding.ActivityAdditionalInfoBinding
+import com.project.fat.manager.UserDataManager
 import com.project.fat.retrofit.client.UserRetrofit
 import retrofit2.Call
 import retrofit2.Callback
@@ -65,15 +67,18 @@ class AdditionalInfoActivity : AppCompatActivity() {
                         val email = result.email
                         val name = result.name
                         val nickname = result.nickname
+                        val money: Int = 0
 
                         Toast.makeText(this@AdditionalInfoActivity, "회원가입이 완료되었습니다.", Toast.LENGTH_SHORT).show()
 
-                        moveActivity()
+                        Toast.makeText(this@AdditionalInfoActivity, "회원가입이 완료되었습니다.", Toast.LENGTH_SHORT).show()
+
+                        moveActivity(nickname, money)
 
                         Log.d(
                             ContentValues.TAG, "Email: $email" +
-                                "\nName: $name" +
-                                "\nNickName: $nickname"
+                                    "\nName: $name" +
+                                    "\nNickName: $nickname"
                         )
                     }
                 }
@@ -85,11 +90,11 @@ class AdditionalInfoActivity : AppCompatActivity() {
             })
     }
 
-    fun moveActivity(){
-        val intent = Intent(applicationContext, BottomNavigationActivity::class.java)
+    fun moveActivity(nickname: String, money: Int){
+        val intent = Intent(this, BottomNavigationActivity::class.java)
         intent.putExtra("nickname", nickname)
+        intent.putExtra("money", money)
         startActivity(intent)
         finish()
-
     }
 }

--- a/fatman/app/src/main/java/com/project/fat/SignInActivity.kt
+++ b/fatman/app/src/main/java/com/project/fat/SignInActivity.kt
@@ -10,6 +10,7 @@ import androidx.datastore.preferences.core.edit
 import androidx.lifecycle.lifecycleScope
 import com.project.fat.data.dto.SignInRequest
 import com.project.fat.data.dto.SignInResponse
+import com.project.fat.data.dto.getUserResponse
 import com.project.fat.dataStore.UserDataStore
 import com.project.fat.dataStore.UserDataStore.dataStore
 import com.project.fat.databinding.ActivitySignInBinding
@@ -82,7 +83,7 @@ class SignInActivity : AppCompatActivity() {
                         )
                     if(nickname != null) {
                         saveToken(accessToken, refreshToken)
-                        moveActivity(nickname, money!!)
+                        getUser(accessToken)
                     } else
                         Toast.makeText(this@SignInActivity, "아이디나 비밀번호가 올바르지 않습니다.", Toast.LENGTH_SHORT).show()
                 }
@@ -118,5 +119,42 @@ class SignInActivity : AppCompatActivity() {
             TokenManager.setToken(accessToken, refreshToken)
             Log.d("saveToken in dataStore", "end")
         }
+    }
+    fun getUser(accessToken: String){
+        loginApiService?.getUser(accessToken)?.enqueue(object : Callback<getUserResponse> {
+            override fun onResponse(
+                call: Call<getUserResponse>,
+                response: Response<getUserResponse>
+            ) {
+                if(response.isSuccessful){
+                    val result = response.body()!!
+                    val email = result.email
+                    val userName = result.name
+                    val nickname = result.nickname
+                    val money = result.money
+                    val address = result.address
+                    val birth = result.birth
+
+                    moveActivity(nickname,money)
+
+
+                    Log.d(
+                        "getUser()", "유저 정보 불러오기" +
+                                "\nEmail: $email" +
+                                "\nName: $userName" +
+                                "\nNickName: $nickname" +
+                                "\nMoney: $money" +
+                                "\nAddress: $address" +
+                                "\nBirth: $birth" +
+                                "\nAccessToken: $accessToken"
+                    )
+
+                }
+
+            }
+            override fun onFailure(call: Call<getUserResponse>, t: Throwable) {
+                //Log.e(ContentValues.TAG, "getOnFailure: ",t.fillInStackTrace())
+            }
+        })
     }
 }

--- a/fatman/app/src/main/java/com/project/fat/SignUp2Activity.kt
+++ b/fatman/app/src/main/java/com/project/fat/SignUp2Activity.kt
@@ -43,16 +43,18 @@ class SignUp2Activity : AppCompatActivity() {
             val email = intent?.getStringExtra("email")
             val password = intent?.getStringExtra("password")
 
-            if(userName.isNullOrEmpty())
+            if (userName.isNullOrEmpty())
                 Toast.makeText(this, "이름을 입력해야합니다", Toast.LENGTH_SHORT).show()
-            else if(address.isNullOrEmpty())
+            else if (address.isNullOrEmpty())
                 Toast.makeText(this, "주소를 입력해야합니다", Toast.LENGTH_SHORT).show()
-            else if(birth.isNullOrEmpty())
+            else if (birth.isNullOrEmpty())
                 Toast.makeText(this, "생년월일을 입력해야합니다", Toast.LENGTH_SHORT).show()
-            else if(nickname.isNullOrEmpty())
+            else if (nickname.isNullOrEmpty())
                 Toast.makeText(this, "닉네임을 입력해야합니다", Toast.LENGTH_SHORT).show()
-            else
+            else {
+                Toast.makeText(this, "회원가입이 완료되었습니다.", Toast.LENGTH_SHORT).show()
                 signUp(email!!, userName, password, nickname, address, birth, loginState)
+            }
         }
     }
 

--- a/fatman/app/src/main/java/com/project/fat/SignUpActivity.kt
+++ b/fatman/app/src/main/java/com/project/fat/SignUpActivity.kt
@@ -39,11 +39,11 @@ class SignUpActivity : AppCompatActivity() {
             password_check = binding.signUpPassword2.text?.toString()
 
             if(email.isNullOrEmpty())
-                Toast.makeText(this, "이메일을 해야합니다", Toast.LENGTH_SHORT).show()
+                Toast.makeText(this, "이메일을 입력해야합니다", Toast.LENGTH_SHORT).show()
             else if(password.isNullOrEmpty())
-                Toast.makeText(this, "비밀번호를 해야합니다", Toast.LENGTH_SHORT).show()
+                Toast.makeText(this, "비밀번호를 입력해야합니다", Toast.LENGTH_SHORT).show()
             else if(password_check.isNullOrEmpty())
-                Toast.makeText(this, "비밀번호를 다시 해야합니다", Toast.LENGTH_SHORT).show()
+                Toast.makeText(this, "비밀번호를 다시 입력해야합니다", Toast.LENGTH_SHORT).show()
             else if (password != password_check)
                 Toast.makeText(this, "비밀번호를 확인하세요", Toast.LENGTH_SHORT).show()
             else

--- a/fatman/app/src/main/java/com/project/fat/data/dto/SignInResponse.kt
+++ b/fatman/app/src/main/java/com/project/fat/data/dto/SignInResponse.kt
@@ -20,14 +20,17 @@ data class SignInResponse(
     @SerializedName("name")
     val name: String,
 
+    @SerializedName("role")
+    val role: String,
+
     @SerializedName("nickname")
     val nickname: String,
 
     @SerializedName("birth")
     val birth: String,
 
-    @SerializedName("social")
-    val social: Boolean,
+    @SerializedName("authProvider")
+    val authProvider: String,
 
     @SerializedName("address")
     val address: String,

--- a/fatman/app/src/main/java/com/project/fat/fragment/bottomNavigationActivity/SettingsFragment.kt
+++ b/fatman/app/src/main/java/com/project/fat/fragment/bottomNavigationActivity/SettingsFragment.kt
@@ -8,15 +8,22 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.datastore.preferences.core.edit
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import com.project.fat.databinding.FragmentSettingsBinding
 import com.project.fat.LoginActivity
+import com.project.fat.dataStore.UserDataStore
 import com.project.fat.manager.TokenManager
+import kotlinx.coroutines.launch
+import com.project.fat.dataStore.UserDataStore.dataStore
 
 class SettingsFragment : Fragment() {
     private var _binding : FragmentSettingsBinding? = null
     private val binding get() = _binding!!
-
+    private val dataStore by lazy {
+        requireContext().dataStore
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -26,19 +33,21 @@ class SettingsFragment : Fragment() {
 
 
         binding.btnLogout.setOnClickListener {
-            if(LoginActivity().google_user != null) {
-                googleLogout()
-                TokenManager.logout()
-                moveLoginActivity()
-            }
-            else {
-                moveLoginActivity()
-            }
+            clearAccessTokenFromDataStore()
+            Log.d("엑세스 토큰 지우기", "${UserDataStore.ACCESS_TOKEN}\n${UserDataStore.REFRESH_TOKEN}")
+            moveLoginActivity()
         }
 
         return binding.root
     }
-
+    private fun clearAccessTokenFromDataStore() {
+        lifecycleScope.launch {
+            this@SettingsFragment.dataStore.edit { preferences ->
+                preferences.remove(UserDataStore.ACCESS_TOKEN)
+                preferences.remove(UserDataStore.REFRESH_TOKEN)
+            }
+        }
+    }
     private fun moveLoginActivity(){
         val intent = Intent(context, LoginActivity()::class.java)
         intent.putExtra("logoutState", false)

--- a/fatman/app/src/main/java/com/project/fat/fragment/bottomNavigationActivity/StoreFragment.kt
+++ b/fatman/app/src/main/java/com/project/fat/fragment/bottomNavigationActivity/StoreFragment.kt
@@ -142,7 +142,7 @@ class StoreFragment : Fragment(), StorePagerAdapter.OnSelectButtonClickListener,
 
     private suspend fun getUserFatman(): UserFatman = suspendCoroutine { continuation ->
         UserFatmanRetrofit.getApiService()!!
-            .getUserFatman(resources.getString(R.string.prefix_of_access_token) + TokenManager.getAccessToken())
+            .getUserFatman(TokenManager.getAccessToken().toString())
             .enqueue(object : Callback<UserFatman> {
                 override fun onResponse(call: Call<UserFatman>, response: Response<UserFatman>) {
                     if (response.isSuccessful) {

--- a/fatman/app/src/main/java/com/project/fat/manager/TokenManager.kt
+++ b/fatman/app/src/main/java/com/project/fat/manager/TokenManager.kt
@@ -27,8 +27,6 @@ object TokenManager {
     fun authorize(
         accessToken: String,
         refreshToken: String,
-        prefixOfAccessToken : String,
-        prefixOfRefreshToken : String,
         callback: (Boolean, String?, String?) -> Unit) {
 
         if(TokenManager.accessToken == null || TokenManager.refreshToken == null) {
@@ -36,7 +34,7 @@ object TokenManager {
             TokenManager.refreshToken = refreshToken
         }
 
-        UserRetrofit.getApiService()!!.authorize(prefixOfRefreshToken+refreshToken, prefixOfAccessToken+accessToken)
+        UserRetrofit.getApiService()!!.authorize(refreshToken, accessToken)
             .enqueue(object : Callback<AuthorizeResponse>{
                 override fun onResponse(
                     call: Call<AuthorizeResponse>,
@@ -44,9 +42,8 @@ object TokenManager {
                 ) {
                     if (response.isSuccessful) {
                         val result = response.headers()
-                        val backendApiAccessToken =
-                            result["Access-Token"]?.replace(prefixOfAccessToken, "")
-                        val backendApiRefreshToken = result["Refresh-Token"]?.replace(prefixOfRefreshToken, "")
+                        val backendApiAccessToken = result["Access-Token"]
+                        val backendApiRefreshToken = result["Refresh-Token"]
                         Log.d(
                             "BackEnd API Authorize Success",
                             "accessToken : $backendApiAccessToken\nrefreshToken : $backendApiRefreshToken"


### PR DESCRIPTION
1. 소셜 로그인과 로컬 로그인이 같은 방식으로 엑세스 토큰의 유무의 따라 자동 로그인 되도록 했습니다. 

       1.1 LoginActivity의 onStart()에서 토큰이 null이 아니면 relogin() 실행
       1.2 사용자가 로그아웃 버튼을 누르면 dataStore에 엑세스 토큰과 리프레시 토큰을 remove()시켜 로그아웃 상태를 유지 
                     합니다.

2.  엑세스 토큰이 필요한 api들 모두 토근값 앞에 문자열이 필요하고 로컬 로그인을 통해 발급 받은 토큰들은 문자열과 함께 reponse가 와서 토큰 저장 방식 바꿨습니다. 

       2.1 소셜 로그인 통한 토큰 값들 dataStore에 저장할때 문자열 붙여서 저장 
       2.2 엑세스 토큰 필요한 api 실행할때 문자열 안붙이고 TokenManager.getAccessToken() 만 불러서 실행하면 됩니다. ( 
             .toString() 붙여야 할수도 있습니다.) 
       2.3 로컬 로그인 시 스토어 화면에서 튕긴 문제 위 토큰 문제여서 해결됐습니다.