### PR TITLE
Fix : createHistory API Datatype

### DIFF
--- a/fatman/.idea/misc.xml
+++ b/fatman/.idea/misc.xml
@@ -1,6 +1,6 @@
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/fatman/app/src/main/java/com/project/fat/ArActivity.kt
+++ b/fatman/app/src/main/java/com/project/fat/ArActivity.kt
@@ -86,6 +86,7 @@ class ArActivity : AppCompatActivity(), OnMapReadyCallback {
 
         modelNode.onTap = { _, _ ->
             val intent = Intent(this@ArActivity, ResultActivity::class.java)
+            LocationProvider.stopLocationUpdates()
             intent.putExtra("glbFileLocation", url)
             startActivity(intent)
         }

--- a/fatman/app/src/main/java/com/project/fat/ResultActivity.kt
+++ b/fatman/app/src/main/java/com/project/fat/ResultActivity.kt
@@ -5,8 +5,10 @@ import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.util.Log
 import android.widget.Toast
+import androidx.lifecycle.ReportFragment.Companion.reportFragment
 import androidx.lifecycle.lifecycleScope
 import com.project.fat.RunningTimeActivity.Companion.runningFinalData
+import com.project.fat.data.dto.CreateHistoryRequest
 import com.project.fat.data.dto.CreateHistoryResponse
 import com.project.fat.dataStore.UserDataStore.dataStore
 import com.project.fat.databinding.ActivityResultBinding
@@ -21,6 +23,10 @@ import kotlinx.coroutines.launch
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.logging.SimpleFormatter
 
 class ResultActivity : AppCompatActivity() {
     private lateinit var binding: ActivityResultBinding
@@ -53,6 +59,7 @@ class ResultActivity : AppCompatActivity() {
 
         binding.goHome.setOnClickListener{
             sendNewHistory()
+            //goHome()
         }
 
         val background = colorOf(resources.getColor(R.color.translucent_white))
@@ -66,12 +73,14 @@ class ResultActivity : AppCompatActivity() {
     }
 
     private fun sendNewHistory(){
-        //REST API createHistory
         lifecycleScope.launch {
-            this@ResultActivity.dataStore.data.map {
-                val accessToken = TokenManager.getAccessToken()
+            val time = LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
 
-                callCreateHistory = HistoryRetrofit.getApiService()!!.createHistory(accessToken.toString(), 1, runningFinalData!!.distance.toDouble(), runningFinalData!!.time)
+            this@ResultActivity.dataStore.data.collect {
+                val accessToken = TokenManager.getAccessToken()
+                val createHistoryRequest = CreateHistoryRequest(1, runningFinalData!!.distance.toDouble(), time)
+
+                callCreateHistory = HistoryRetrofit.getApiService()!!.createHistory(accessToken.toString(), createHistoryRequest)
                 callCreateHistory.enqueue(object : Callback<CreateHistoryResponse>{
                     override fun onResponse(
                         call: Call<CreateHistoryResponse>,

--- a/fatman/app/src/main/java/com/project/fat/RunningTimeActivity.kt
+++ b/fatman/app/src/main/java/com/project/fat/RunningTimeActivity.kt
@@ -52,7 +52,7 @@ class RunningTimeActivity : AppCompatActivity() {
         binding.imageView.setOnClickListener {
             saveRunningFinalData()
             //임시
-            LocationProvider.stopLocationUpdates()
+            fusedLocationClient.removeLocationUpdates(locationCallback)
             startActivity(Intent(this, ArActivity::class.java))
         }
 

--- a/fatman/app/src/main/java/com/project/fat/data/dto/AddUserMonsterRequest.kt
+++ b/fatman/app/src/main/java/com/project/fat/data/dto/AddUserMonsterRequest.kt
@@ -1,0 +1,8 @@
+package com.project.fat.data.dto
+
+import com.google.gson.annotations.SerializedName
+
+data class AddUserMonsterRequest(
+    @SerializedName("monster_id")
+    val monster_id : Long
+)

--- a/fatman/app/src/main/java/com/project/fat/data/dto/CreateHistoryRequest.kt
+++ b/fatman/app/src/main/java/com/project/fat/data/dto/CreateHistoryRequest.kt
@@ -1,0 +1,9 @@
+package com.project.fat.data.dto
+import com.google.gson.annotations.SerializedName
+import java.time.LocalDateTime
+
+data class CreateHistoryRequest(
+    @SerializedName("monster_num") val monsterNum : Int,
+    @SerializedName("distance") val distance : Double,
+    @SerializedName("date") val date : String
+)

--- a/fatman/app/src/main/java/com/project/fat/data/dto/CreateHistoryRequest.kt
+++ b/fatman/app/src/main/java/com/project/fat/data/dto/CreateHistoryRequest.kt
@@ -1,9 +1,8 @@
 package com.project.fat.data.dto
 import com.google.gson.annotations.SerializedName
-import java.time.LocalDateTime
 
 data class CreateHistoryRequest(
-    @SerializedName("monster_num") val monsterNum : Int,
-    @SerializedName("distance") val distance : Double,
-    @SerializedName("date") val date : String
+    @SerializedName("monster_num") val monsterNum: Int,
+    @SerializedName("distance") val distance: Double,
+    @SerializedName("date") val date: String
 )

--- a/fatman/app/src/main/java/com/project/fat/data/dto/CreateHistoryResponse.kt
+++ b/fatman/app/src/main/java/com/project/fat/data/dto/CreateHistoryResponse.kt
@@ -4,7 +4,7 @@ import java.time.LocalDateTime
 
 data class CreateHistoryResponse (
     val monsterNum: Long,
-    val distance: Long,
+    val distance: Double,
     val id: Long,
     val user: CreateHistoryUser,
     val date: String

--- a/fatman/app/src/main/java/com/project/fat/data/dto/CreateHistoryResponse.kt
+++ b/fatman/app/src/main/java/com/project/fat/data/dto/CreateHistoryResponse.kt
@@ -1,5 +1,7 @@
 package com.project.fat.data.dto
 
+import java.time.LocalDateTime
+
 data class CreateHistoryResponse (
     val monsterNum: Long,
     val distance: Long,

--- a/fatman/app/src/main/java/com/project/fat/data/dto/ErrorResponse.kt
+++ b/fatman/app/src/main/java/com/project/fat/data/dto/ErrorResponse.kt
@@ -1,0 +1,7 @@
+package com.project.fat.data.dto
+
+data class ErrorResponse(
+    val errorMessage : String,
+    val httpStatus : String,
+    val code : String
+)

--- a/fatman/app/src/main/java/com/project/fat/data/dto/GetHistoryResponse.kt
+++ b/fatman/app/src/main/java/com/project/fat/data/dto/GetHistoryResponse.kt
@@ -9,7 +9,7 @@ data class GetHistoryResponseElement (
     val user: User,
     val date: LocalDate,
     val monsterNum: Long,
-    val distance: Long
+    val distance: Double
 )
 
 data class User (

--- a/fatman/app/src/main/java/com/project/fat/dataStore/UserDataStore.kt
+++ b/fatman/app/src/main/java/com/project/fat/dataStore/UserDataStore.kt
@@ -34,17 +34,5 @@ object UserDataStore{
             Log.e("saveSelectedFatman", "error : ${e.message}", e)
         }
     }
-
-    suspend fun saveMoney(context: Context, money : Long){
-        try{
-            context.dataStore.edit {
-                Log.d("saveMoney", "edit start")
-                it[MONEY]=money
-                Log.d("saveMoney", "edit end")
-            }
-        }catch (e: Exception){
-            Log.e("saveMoney", "error : ${e.message}", e)
-        }
-    }
 }
 

--- a/fatman/app/src/main/java/com/project/fat/fragment/bottomNavigationActivity/CalendarFragment.kt
+++ b/fatman/app/src/main/java/com/project/fat/fragment/bottomNavigationActivity/CalendarFragment.kt
@@ -31,6 +31,7 @@ import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 class CalendarFragment : Fragment() {
     private lateinit var calendarView: MaterialCalendarView
@@ -48,7 +49,7 @@ class CalendarFragment : Fragment() {
 
         calendarView = binding.calendarview
 
-        var targetDate: LocalDate = LocalDate.now()
+        var targetDate = LocalDate.now()
 
         fun fetchHistory(targetDate: LocalDate){
             HistoryRetrofit.getApiService()!!

--- a/fatman/app/src/main/java/com/project/fat/fragment/bottomNavigationActivity/FatbookFragment.kt
+++ b/fatman/app/src/main/java/com/project/fat/fragment/bottomNavigationActivity/FatbookFragment.kt
@@ -10,16 +10,12 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import com.project.fat.R
 import com.project.fat.adapter.GridviewAdapter
-import com.project.fat.data.dto.Fatman
 import com.project.fat.data.dto.Monster
 import com.project.fat.databinding.FragmentFatbookBinding
 import com.project.fat.manager.TokenManager
-import com.project.fat.retrofit.api_interface.FatmanService
-import com.project.fat.retrofit.api_interface.MonsterService
-import com.project.fat.retrofit.client.FatmanRetrofit
-import com.project.fat.retrofit.client.MonsterRetrofit
+import com.project.fat.retrofit.api_interface.UserMonsterService
+import com.project.fat.retrofit.client.UserMonsterRetrofit
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
@@ -36,7 +32,7 @@ private const val ARG_PARAM2 = "param2"
  */
 class FatbookFragment : Fragment() {
     private lateinit var fatbookBinding: FragmentFatbookBinding
-    private var UserMonsterApiService: MonsterService? = MonsterRetrofit.getApiService()
+    private var UserMonsterApiService: UserMonsterService? = UserMonsterRetrofit.getApiService()
 
     // TODO: Rename and change types of parameters
     private var param1: String? = null

--- a/fatman/app/src/main/java/com/project/fat/fragment/bottomNavigationActivity/StoreFragment.kt
+++ b/fatman/app/src/main/java/com/project/fat/fragment/bottomNavigationActivity/StoreFragment.kt
@@ -13,7 +13,7 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.tabs.TabLayoutMediator
 import com.project.fat.R
-import com.project.fat.data.dto.AddUserFatmanResponse
+import com.project.fat.data.dto.ErrorResponse
 import com.project.fat.data.dto.Fatman
 import com.project.fat.data.dto.UserFatman
 import com.project.fat.data.store.StoreAvata
@@ -195,10 +195,10 @@ class StoreFragment : Fragment(), StorePagerAdapter.OnSelectButtonClickListener,
         }
         else if(data.cost <= UserDataManager.getMoney()!!){
             UserFatmanRetrofit.getApiService()!!.addUserFatman(TokenManager.getAccessToken()!!, data.id)
-                .enqueue(object : Callback<AddUserFatmanResponse>{
+                .enqueue(object : Callback<ErrorResponse>{
                     override fun onResponse(
-                        call: Call<AddUserFatmanResponse>,
-                        response: Response<AddUserFatmanResponse>
+                        call: Call<ErrorResponse>,
+                        response: Response<ErrorResponse>
                     ) {
                         if (response.isSuccessful) {
                             if(response.code() == 404){
@@ -217,7 +217,7 @@ class StoreFragment : Fragment(), StorePagerAdapter.OnSelectButtonClickListener,
                         }
                     }
 
-                    override fun onFailure(call: Call<AddUserFatmanResponse>, t: Throwable) {
+                    override fun onFailure(call: Call<ErrorResponse>, t: Throwable) {
                         Log.d("addUserFatman Failure", "Fail : ${t.printStackTrace()}\n Error message : ${t.message}")
                     }
 

--- a/fatman/app/src/main/java/com/project/fat/retrofit/api_interface/HistoryService.kt
+++ b/fatman/app/src/main/java/com/project/fat/retrofit/api_interface/HistoryService.kt
@@ -1,5 +1,6 @@
 package com.project.fat.retrofit.api_interface
 
+import com.project.fat.data.dto.CreateHistoryRequest
 import com.project.fat.data.dto.CreateHistoryResponse
 import com.project.fat.data.dto.GetHistoryResponse
 import retrofit2.Call
@@ -10,20 +11,19 @@ import retrofit2.http.Header
 import retrofit2.http.POST
 import retrofit2.http.Path
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 interface HistoryService {
     @GET("history")
     fun getHistory(
-        targetDate: LocalDate,
-        @Header("access_token") accessToken : String
+        @Header("access_token") accessToken: String,
+        @Body targetDate: LocalDate
     ) : Call<GetHistoryResponse>
 
     @POST("history")
     fun createHistory(
-        @Header("Access-Token") accessToken : String,
-        monsterNum : Int,
-        distance : Double,
-        date : String
+        @Header("access_token") accessToken : String,
+        @Body createHistoryRequest: CreateHistoryRequest
     ) :Call<CreateHistoryResponse>
 
     @DELETE("history")

--- a/fatman/app/src/main/java/com/project/fat/retrofit/api_interface/HistoryService.kt
+++ b/fatman/app/src/main/java/com/project/fat/retrofit/api_interface/HistoryService.kt
@@ -16,13 +16,13 @@ import java.time.LocalDateTime
 interface HistoryService {
     @GET("history")
     fun getHistory(
-        @Header("access_token") accessToken: String,
+        @Header("Access-Token") accessToken: String,
         @Body targetDate: LocalDate
     ) : Call<GetHistoryResponse>
 
     @POST("history")
     fun createHistory(
-        @Header("access_token") accessToken : String,
+        @Header("Access-Token") accessToken : String,
         @Body createHistoryRequest: CreateHistoryRequest
     ) :Call<CreateHistoryResponse>
 

--- a/fatman/app/src/main/java/com/project/fat/retrofit/api_interface/UserFatmanService.kt
+++ b/fatman/app/src/main/java/com/project/fat/retrofit/api_interface/UserFatmanService.kt
@@ -1,6 +1,7 @@
 package com.project.fat.retrofit.api_interface
 
-import com.project.fat.data.dto.AddUserFatmanResponse
+
+import com.project.fat.data.dto.ErrorResponse
 import com.project.fat.data.dto.UserFatman
 import retrofit2.Call
 import retrofit2.http.GET
@@ -12,7 +13,7 @@ interface UserFatmanService {
     @PUT("userfatman")
     fun addUserFatman(
         @Header("Access-Token") accessToken : String,
-        @Path("fatmanId") fatmanId : Long) : Call<AddUserFatmanResponse>
+        @Path("fatmanId") fatmanId : Long) : Call<ErrorResponse>
 
     @GET("userfatman")
     fun getUserFatman(

--- a/fatman/app/src/main/java/com/project/fat/retrofit/api_interface/UserMonsterService.kt
+++ b/fatman/app/src/main/java/com/project/fat/retrofit/api_interface/UserMonsterService.kt
@@ -1,0 +1,23 @@
+package com.project.fat.retrofit.api_interface
+
+import com.project.fat.data.dto.ErrorResponse
+import com.project.fat.data.dto.Monster
+import com.project.fat.data.dto.AddUserMonsterRequest
+import retrofit2.Call
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.Header
+import retrofit2.http.POST
+
+interface UserMonsterService {
+    @GET("user_monster")
+    fun getUserMonster(
+        @Header("Access-Token") accessToken : String
+    ) : Call<ArrayList<Monster>>
+
+    @POST("user_monster")
+    fun addUserMonster(
+        @Header("Access-Token") accessToken : String,
+        @Body addUserMonsterRequest: AddUserMonsterRequest
+    ) : Call<ErrorResponse>
+}

--- a/fatman/app/src/main/java/com/project/fat/retrofit/client/UserMonsterRetrofit.kt
+++ b/fatman/app/src/main/java/com/project/fat/retrofit/client/UserMonsterRetrofit.kt
@@ -2,7 +2,8 @@ package com.project.fat.retrofit.client
 
 import com.google.gson.GsonBuilder
 import com.project.fat.BuildConfig
-import com.project.fat.retrofit.api_interface.MonsterService
+import com.project.fat.retrofit.api_interface.UserMonsterService
+import com.project.fat.retrofit.converterFactory.NullOnEmptyConverterFactory
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
@@ -11,8 +12,8 @@ import retrofit2.converter.gson.GsonConverterFactory
 object UserMonsterRetrofit {
     private const val BASE_URL = BuildConfig.backend_api_end_point
 
-    fun getApiService(): MonsterService?{
-        return getInstance()?.create(MonsterService::class.java)
+    fun getApiService(): UserMonsterService?{
+        return getInstance()?.create(UserMonsterService::class.java)
     }
 
     private fun getInstance(): Retrofit? {
@@ -25,6 +26,7 @@ object UserMonsterRetrofit {
 
         return Retrofit.Builder()
             .baseUrl(BASE_URL)
+            .addConverterFactory(NullOnEmptyConverterFactory())
             .addConverterFactory(GsonConverterFactory.create(gson))
             .client(httpClient.build())
             .build()


### PR DESCRIPTION
1. 액세스 토큰이 발행되기 이전에 만들어두었던 CreateHistory API 관련 dto, service, retrofit client를 현재 API 버전에 맞게 수정하였습니다.
	- 액세스 토큰의 Header 이름
	- 잘못 설정되어 있었던 distance 타입 대거 변경 (Long -> Double)
2. addUserMonster도 1번과 비슷한 이유로 변경되었습니다.
	- response dto 구조 : null -> ErrorResponse(기존의 getUserFatmanResponse의 이름이 변경되었습니다.)
	- request dto 추가
	
* 결과 화면에 addUserMonster가 삭제되어 있었던 문제를 해결하였습니다.(push를 안 한 상태로 pull한 내용을 반영하다가 짤린 듯 합니다.) 그렇지만, 전체 몬스터 리스트를 받을 수 있는 API가 존재하지 않고 요청을 드려도 완성했다는 소식이 들리지 않아 앱 자체에서 몬스터 리스트를 만들고 관리하여 랜덤으로 뽑는 MonsterManager를 만들어 Monster를 구현하였기에 해당 메소드는 항상 정상 작동이 불가능합니다.
monster API에서 addMonster를 하기 위해선 몬스터 id와 imageurl를 넣어주어야 하는데 imageurl를 넣기 위해서 어느 사이트든지 해당 이미지가 올라가야 합니다. 깃허브에 올라간 이미지를 통해 주소를 넣어주고 싶어도 addMonster를 사용하고자 하면
{
    "errorMessage": "Required request parameter 'name' for method parameter type String is not present",
    "httpStatus": "BAD_REQUEST",
    "code": null
}
이런 오류코드가 발생해서 서버에 해당 몬스터 리스트를 추가하지 못하다보니 존재하지 않는 몬스터라며 addUserMonster가 진행되지 않습니다. 아무래도 이번 CreateHistory가 과거를 기준으로 만든 소스코드를 기반으로 만들다가 오랫동안 원인도 잊고 통신이 안 되었던 것이기에 좀 더 addMonster에 대해 알아봐야 겠지만, 현재 구현된 내용을 보고드리기 위해서 현재 상황을 정리하여 보내드립니다.